### PR TITLE
Fix Portfolio Performance Calculation

### DIFF
--- a/backend/app/services/portfolio_service.py
+++ b/backend/app/services/portfolio_service.py
@@ -162,6 +162,8 @@ class PortfolioService:
                 - totalDividends: Total dividends received
                 - totalUnrealizedGainLoss: Total unrealized gain/loss
                 - totalRealizedGainLoss: Total realized gain/loss
+                - totalSaleProceeds: Total proceeds from sales
+                - totalOriginalCost: Total original cost of sold positions
                 - totalGainLoss: Total gain/loss
                 - is_archived: Whether portfolio is archived
 
@@ -184,7 +186,11 @@ class PortfolioService:
                 )
 
                 if has_transactions:
-                    # Calculate totals from portfolio_funds_data
+                    # Get realized gains records
+                    realized_gains = RealizedGainLoss.query.filter_by(
+                        portfolio_id=portfolio.id
+                    ).all()
+
                     totals = {
                         "totalValue": sum(
                             pf["current_value"] for pf in portfolio_funds_data
@@ -200,6 +206,12 @@ class PortfolioService:
                         ),
                         "totalRealizedGainLoss": sum(
                             pf["realized_gain_loss"] for pf in portfolio_funds_data
+                        ),
+                        "totalSaleProceeds": sum(
+                            gain.sale_proceeds for gain in realized_gains
+                        ),
+                        "totalOriginalCost": sum(
+                            gain.cost_basis for gain in realized_gains
                         ),
                         "totalGainLoss": sum(
                             pf["total_gain_loss"] for pf in portfolio_funds_data

--- a/frontend/src/pages/Overview.js
+++ b/frontend/src/pages/Overview.js
@@ -43,6 +43,8 @@ const Overview = () => {
           totalCost: acc.totalCost + portfolio.totalCost,
           totalUnrealizedGainLoss: acc.totalUnrealizedGainLoss + portfolio.totalUnrealizedGainLoss,
           totalRealizedGainLoss: acc.totalRealizedGainLoss + portfolio.totalRealizedGainLoss,
+          totalSaleProceeds: acc.totalSaleProceeds + portfolio.totalSaleProceeds,
+          totalOriginalCost: acc.totalOriginalCost + portfolio.totalOriginalCost,
           totalGainLoss: acc.totalGainLoss + portfolio.totalGainLoss,
         };
       },
@@ -51,14 +53,19 @@ const Overview = () => {
         totalCost: 0,
         totalUnrealizedGainLoss: 0,
         totalRealizedGainLoss: 0,
+        totalSaleProceeds: 0,
+        totalOriginalCost: 0,
         totalGainLoss: 0,
       }
     );
 
     const performance = (
-      (totals.totalValue / (totals.totalCost + totals.totalRealizedGainLoss) - 1) *
+      ((totals.totalValue + totals.totalSaleProceeds) /
+        (totals.totalCost + totals.totalOriginalCost) -
+        1) *
       100
     ).toFixed(2);
+
     return {
       ...totals,
       performance: performance,
@@ -270,7 +277,7 @@ const Overview = () => {
             <tr>
               <th>Portfolio</th>
               <th>Current Value</th>
-              <th>Cost Basis</th>
+              <th>Current Cost Basis</th>
               <th>Unrealized Gain/Loss</th>
               <th>Realized Gain/Loss</th>
               <th>Performance</th>
@@ -279,7 +286,8 @@ const Overview = () => {
           <tbody>
             {portfolioSummary.map((portfolio) => {
               const performance = (
-                (portfolio.totalValue / (portfolio.totalCost + portfolio.totalRealizedGainLoss) -
+                ((portfolio.totalValue + portfolio.totalSaleProceeds) /
+                  (portfolio.totalCost + portfolio.totalOriginalCost) -
                   1) *
                 100
               ).toFixed(2);


### PR DESCRIPTION
# Fix Portfolio Performance Calculation

## Description
This PR fixes the portfolio performance calculation to accurately reflect returns when positions are sold. The previous calculation did not properly account for the cost basis of sold positions, leading to incorrect performance percentages.

## Changes

### Backend Changes
1. Modified `PortfolioService.get_portfolio_summary()` to include:
   - Total sale proceeds from realized gains
   - Total original cost basis of sold positions
   - 
```diff:backend/app/services/portfolio_service.py
    # Get realized gains records
    realized_gains = RealizedGainLoss.query.filter_by(
        portfolio_id=portfolio.id
    ).all()

    totals = {
        "totalValue": sum(pf["current_value"] for pf in portfolio_funds_data),
        "totalCost": sum(pf["total_cost"] for pf in portfolio_funds_data),
        "totalDividends": sum(pf["total_dividends"] for pf in portfolio_funds_data),
        "totalUnrealizedGainLoss": sum(pf["unrealized_gain_loss"] for pf in portfolio_funds_data),
        "totalRealizedGainLoss": sum(pf["realized_gain_loss"] for pf in portfolio_funds_data),
+       "totalSaleProceeds": sum(gain.sale_proceeds for gain in realized_gains),
+       "totalOriginalCost": sum(gain.cost_basis for gain in realized_gains),
        "totalGainLoss": sum(pf["total_gain_loss"] for pf in portfolio_funds_data),
    }
```

### Frontend Changes
1. Updated performance calculation in Overview.js:
2. Updated column header for clarity:


## Performance Calculation
The new calculation properly accounts for:
1. Current holdings: Current market value and cost basis
2. Sold positions: Sale proceeds and original cost basis

Formula: `((Current Value + Total Sale Proceeds) / (Current Cost Basis + Original Cost of Sold Positions) - 1) * 100`

Example:
- Current Value: €567.79
- Sale Proceeds: €2,935.10
- Current Cost Basis: €482.23
- Original Cost of Sold Positions: €2,492.77
- Performance: ((567.79 + 2,935.10) / (482.23 + 2,492.77)) - 1 = 17.74%
