### PR TITLE
chore: add uv exclude-newer for supply-chain protection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ dev = [
     "ruff>=0.8.0,<1.0.0",
 ]
 
+[tool.uv]
+# Only install package versions published at least 7 days ago.
+# Mitigates supply-chain attacks where compromised versions are pushed to existing packages.
+exclude-newer = "7 days"
+
 [tool.ruff]
 
 # Same as Black


### PR DESCRIPTION
## Summary

Adds `exclude-newer = "7 days"` to `[tool.uv]` in pyproject.toml. This prevents uv from installing package versions published less than 7 days ago, mitigating supply-chain attacks where compromised versions are pushed to existing packages.

## Test plan
- [x] `uv sync` works correctly with the setting
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)