### PR TITLE
fix: resolve mobile fullscreen chart overlap and button interaction

### DIFF
--- a/frontend/src/components/ValueChart.css
+++ b/frontend/src/components/ValueChart.css
@@ -298,7 +298,7 @@
 
 .chart-container-fullscreen {
   position: absolute;
-  top: 0;
+  top: 60px;
   left: 0;
   right: 0;
   bottom: 0;
@@ -441,9 +441,9 @@
 
 /* Toggle buttons for showing/hiding controls */
 .fullscreen-toggle-buttons {
-  position: absolute;
+  position: fixed;
   top: 8px;
-  left: 64px;
+  left: 8px;
   z-index: 10003;
   display: flex;
   gap: var(--space-2);
@@ -478,6 +478,28 @@
 
 .control-toggle-button:active {
   transform: scale(0.95);
+}
+
+/* Fullscreen control panels - positioned below the toggle buttons */
+.fullscreen-metric-panel,
+.fullscreen-zoom-panel {
+  position: fixed;
+  top: 60px;
+  left: 8px;
+  right: 8px;
+  z-index: 10002;
+  background-color: rgba(255, 255, 255, 0.95);
+  border-radius: var(--radius-md);
+  padding: 6px;
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-1);
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* Control panels - horizontal scrollable single row */
@@ -739,6 +761,12 @@
 }
 
 [data-theme="dark"] .chart-fullscreen-container .chart-controls {
+  background-color: rgba(30, 30, 30, 0.95);
+  scrollbar-color: var(--color-primary) var(--color-neutral-100);
+}
+
+[data-theme="dark"] .fullscreen-metric-panel,
+[data-theme="dark"] .fullscreen-zoom-panel {
   background-color: rgba(30, 30, 30, 0.95);
   scrollbar-color: var(--color-primary) var(--color-neutral-100);
 }

--- a/frontend/src/components/ValueChart.js
+++ b/frontend/src/components/ValueChart.js
@@ -348,7 +348,7 @@ const ValueChart = ({
   useEffect(() => {
     const instance = chartInstanceRef.current;
     if (!instance) return;
-    const chartHeight = isFullScreen ? window.innerHeight - 100 : height;
+    const chartHeight = isFullScreen ? window.innerHeight - 160 : height;
     instance.updateOptions({ chart: { height: chartHeight } }, false, false);
   }, [isFullScreen, height]);
 


### PR DESCRIPTION
## Summary
- Chart was rendering from `top: 0` in fullscreen, overlapping the close/toggle buttons — fixed by offsetting the chart container by 60px
- Gear/magnifying glass toggle buttons were unresponsive because ApexCharts' touch event capture layer was intercepting taps; fixed by switching to `position: fixed` (same as the already-working close button)
- Added `position: fixed` styles for the metric/zoom panels so they render correctly above the chart when toggled
- Added dark mode support (`[data-theme="dark"]`) for the new fullscreen panel styles
- Adjusted fullscreen chart height from `window.innerHeight - 100` to `window.innerHeight - 160` to account for the 60px top offset

## Test plan
- [ ] Open a chart on mobile and tap the fullscreen button
- [ ] Verify the chart renders below the close (×) and toggle (⚙️/🔍) buttons with no overlap
- [ ] Tap the ⚙️ and 🔍 buttons and verify they open their respective control panels
- [ ] Verify control panels render correctly above the chart
- [ ] Toggle dark mode and verify panels use dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)