### PR TITLE
fix: return TransactionResponse from create/update endpoints to include fundName

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -116,9 +116,18 @@ jobs:
 
       - name: Test frontend proxy with custom backend name
         run: |
-          RESPONSE=$(curl -s http://localhost/api/system/health)
-          echo "Proxied health response: $RESPONSE"
-          echo "$RESPONSE" | jq -e '.status == "healthy"' || exit 1
+          echo "Testing proxied health endpoint through nginx..."
+          for i in {1..30}; do
+            RESPONSE=$(curl -s --max-time 5 http://localhost/api/system/health) && \
+              echo "$RESPONSE" | jq -e '.status == "healthy"' > /dev/null 2>&1 && \
+              echo "Proxied health response: $RESPONSE" && exit 0
+            echo "Attempt $i: proxy not ready yet, retrying..."
+            sleep 2
+          done
+          echo "Frontend proxy health check timeout"
+          echo "Last response: $RESPONSE"
+          docker compose logs frontend
+          exit 1
 
       - name: Check backend logs on failure
         if: failure()

--- a/backend/internal/api/handlers/transactions.go
+++ b/backend/internal/api/handlers/transactions.go
@@ -103,7 +103,7 @@ func (h *TransactionHandler) GetTransaction(w http.ResponseWriter, r *http.Reque
 //
 // Endpoint: POST /api/transaction
 // Request Body: CreateTransactionRequest (portfolioFundId, date, type, shares, costPerShare)
-// Response: 201 Created with Transaction
+// Response: 201 Created with TransactionResponse
 // Error: 400 Bad Request if validation fails or request body is invalid
 // Error: 500 Internal Server Error if creation fails
 func (h *TransactionHandler) CreateTransaction(w http.ResponseWriter, r *http.Request) {
@@ -144,7 +144,7 @@ func (h *TransactionHandler) CreateTransaction(w http.ResponseWriter, r *http.Re
 //
 // Endpoint: PUT /api/transaction/{uuid}
 // Request Body: UpdateTransactionRequest (all fields optional)
-// Response: 200 OK with updated Transaction
+// Response: 200 OK with updated TransactionResponse
 // Error: 400 Bad Request if transaction ID is invalid (validated by middleware) or validation fails
 // Error: 404 Not Found if transaction not found
 // Error: 500 Internal Server Error if update fails

--- a/backend/internal/api/handlers/transactions_test.go
+++ b/backend/internal/api/handlers/transactions_test.go
@@ -275,6 +275,7 @@ func TestTransactionHandler_GetTransaction(t *testing.T) {
 	})
 }
 
+//nolint:gocyclo // Test function with multiple subtests and assertions.
 func TestTransactionHandler_CreateTransaction(t *testing.T) {
 	setupHandler := func(t *testing.T) (*TransactionHandler, *sql.DB) {
 		t.Helper()
@@ -307,7 +308,7 @@ func TestTransactionHandler_CreateTransaction(t *testing.T) {
 			t.Errorf("Expected 201, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var response model.Transaction
+		var response model.TransactionResponse
 		//nolint:errcheck // Test assertion - decode failure would cause test to fail anyway
 		json.NewDecoder(w.Body).Decode(&response)
 
@@ -316,6 +317,9 @@ func TestTransactionHandler_CreateTransaction(t *testing.T) {
 		}
 		if response.PortfolioFundID != pf.ID {
 			t.Errorf("Expected portfolioFundId %s, got %s", pf.ID, response.PortfolioFundID)
+		}
+		if response.FundName != fund.Name {
+			t.Errorf("Expected fundName %s, got %s", fund.Name, response.FundName)
 		}
 		if response.Type != "buy" {
 			t.Errorf("Expected type buy, got %s", response.Type)
@@ -539,12 +543,15 @@ func TestTransactionHandler_UpdateTransaction(t *testing.T) {
 			t.Errorf("Expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var response model.Transaction
+		var response model.TransactionResponse
 		//nolint:errcheck // Test assertion - decode failure would cause test to fail anyway
 		json.NewDecoder(w.Body).Decode(&response)
 
 		if response.ID != tx.ID {
 			t.Errorf("Expected transaction ID %s, got %s", tx.ID, response.ID)
+		}
+		if response.FundName != fund.Name {
+			t.Errorf("Expected fundName %s, got %s", fund.Name, response.FundName)
 		}
 		if response.Shares != 75.0 {
 			t.Errorf("Expected shares 75.0, got %f", response.Shares)
@@ -583,7 +590,7 @@ func TestTransactionHandler_UpdateTransaction(t *testing.T) {
 			t.Errorf("Expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var response model.Transaction
+		var response model.TransactionResponse
 		//nolint:errcheck // Test assertion - decode failure would cause test to fail anyway
 		json.NewDecoder(w.Body).Decode(&response)
 

--- a/backend/internal/service/transaction_service.go
+++ b/backend/internal/service/transaction_service.go
@@ -93,10 +93,10 @@ func (s *TransactionService) GetTransaction(transactionID string) (model.Transac
 // For sell transactions, validates sufficient shares and automatically creates
 // a RealizedGainLoss record with the calculated cost basis and gain/loss.
 //
-// Returns the created transaction on success.
+// Returns an enriched TransactionResponse on success.
 // Returns ErrInsufficientShares if selling more shares than currently held.
 // Returns an error if date parsing fails or database insertion fails.
-func (s *TransactionService) CreateTransaction(ctx context.Context, req request.CreateTransactionRequest) (*model.Transaction, error) {
+func (s *TransactionService) CreateTransaction(ctx context.Context, req request.CreateTransactionRequest) (*model.TransactionResponse, error) {
 	txLog.DebugContext(ctx, "creating transaction", "portfolioFundID", req.PortfolioFundID, "type", req.Type)
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -149,7 +149,12 @@ func (s *TransactionService) CreateTransaction(ctx context.Context, req request.
 	}
 
 	txLog.InfoContext(ctx, "transaction created", "transactionID", transaction.ID, "type", transaction.Type, "shares", transaction.Shares)
-	return transaction, nil
+
+	resp, err := s.GetTransaction(transaction.ID)
+	if err != nil {
+		return nil, fmt.Errorf("get created transaction response: %w", err)
+	}
+	return &resp, nil
 }
 
 // UpdateTransaction updates an existing transaction with the provided changes.
@@ -164,7 +169,7 @@ func (s *TransactionService) CreateTransaction(ctx context.Context, req request.
 // earlier of old/new dates, and both old and new portfolio-funds are regenerated
 // separately (Issue #35, Edge Case 3).
 //
-// Returns the updated transaction on success.
+// Returns an enriched TransactionResponse on success.
 // Returns ErrTransactionNotFound if the transaction does not exist.
 // Returns ErrInsufficientShares if selling more shares than currently held.
 //
@@ -173,7 +178,7 @@ func (s *TransactionService) UpdateTransaction(
 	ctx context.Context,
 	id string,
 	req request.UpdateTransactionRequest,
-) (*model.Transaction, error) {
+) (*model.TransactionResponse, error) {
 	txLog.DebugContext(ctx, "updating transaction", "transactionID", id)
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -238,7 +243,12 @@ func (s *TransactionService) UpdateTransaction(
 	}
 
 	txLog.InfoContext(ctx, "transaction updated", "transactionID", id)
-	return &transaction, nil
+
+	resp, err := s.GetTransaction(id)
+	if err != nil {
+		return nil, fmt.Errorf("get updated transaction response: %w", err)
+	}
+	return &resp, nil
 }
 
 // DeleteTransaction removes a transaction from the system with proper cleanup.


### PR DESCRIPTION
The create and update transaction endpoints returned a bare Transaction model (missing fundName), causing the frontend to show empty fund names until page refresh. Now both endpoints return an enriched TransactionResponse with fundName populated, matching the get/list endpoints.