### PR TITLE
fix(backend): bump Go to 1.26.4 and drop deprecated chi RealIP

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.4'
           cache: true
           cache-dependency-path: backend/go.sum
 
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.4'
           cache: true
           cache-dependency-path: backend/go.sum
 
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.4'
           cache: true
           cache-dependency-path: backend/go.sum
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 # Multi-stage build for optimal image size
-FROM golang:1.26-alpine AS builder
+# Pinned to match the go directive in go.mod (>= 1.26.4); the floating
+# golang:1.26-alpine tag can lag behind and fail `go mod download`.
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /app
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/ndewijer/Investment-Portfolio-Manager/backend
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/fernet/fernet-go v0.0.0-20240119011108-303da6aec611

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -32,7 +32,10 @@ func NewRouter(
 
 	// Global middleware
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
+	// NOTE: chi's middleware.RealIP is intentionally not used — it is deprecated as
+	// vulnerable to IP spoofing (GHSA-3fxj-6jh8-hvhx) because it rewrites RemoteAddr
+	// from untrusted X-Forwarded-For / X-Real-IP headers. The logger derives the
+	// client IP directly from those headers instead (see middleware.clientIP).
 	r.Use(custommiddleware.Logger)
 	r.Use(middleware.Recoverer)
 


### PR DESCRIPTION
## Why

The open Dependabot backend PRs **#208** (chi 5.2.5→5.3.0, modernc.org/sqlite 1.50→1.51) and **#206** (golangci-lint-action 9.2.0→9.2.1) are currently **BLOCKED** by failing CI. Their failures stem from two issues that exist on `main` independent of those bumps, so this PR fixes the shared root causes first. Once merged, #208 and #206 can be rebased and will go green.

## What

**1. Go toolchain 1.26.2 → 1.26.4** (`backend/go.mod`, 3 pins in `.github/workflows/backend-ci.yml`, `backend/Dockerfile`)

The Security Scan (`govulncheck`) flags 4 Go **standard-library** advisories on 1.26.2:

| Advisory | Package | Fixed in |
|---|---|---|
| GO-2026-4918 | net/http | go1.26.3 |
| GO-2026-4971 | net | go1.26.3 |
| GO-2026-5037 | crypto/x509 | go1.26.4 |
| GO-2026-5039 | net/textproto | go1.26.4 |

1.26.4 is required (crypto/x509 + net/textproto fixes only land there). The `Dockerfile` builder is pinned to `golang:1.26.4-alpine` because the floating `golang:1.26-alpine` tag can lag behind the `go` directive and break `go mod download`.

**2. Remove deprecated `chi/middleware.RealIP`** (`backend/internal/api/router.go`)

chi v5.3.0 (incoming via #208) deprecates `middleware.RealIP` — it rewrites `RemoteAddr` from spoofable `X-Forwarded-For` / `X-Real-IP` headers ([GHSA-3fxj-6jh8-hvhx](https://github.com/advisories/GHSA-3fxj-6jh8-hvhx)) — and staticcheck rejects it via SA1019. It's removed rather than replaced: the request logger already derives the client IP directly from those headers (`middleware.clientIP`), so logging is unchanged and `RemoteAddr` now reflects the real TCP peer.

## Verification (local, go1.26.4)

- `go build ./...` ✓
- `go vet ./...` ✓
- `golangci-lint run` — 0 issues ✓
- `govulncheck ./...` — 0 affecting vulnerabilities ✓
- `go test -race ./...` — all pass ✓
- backend Docker image build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)