### PR TITLE
ci: run E2E in prebaked Playwright image to fix docker-integration hang

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -9,6 +9,7 @@ on:
       - 'frontend/Dockerfile'
       - 'frontend/nginx.conf'
       - 'docker-compose.yml'
+      - 'scripts/test-docker-integration.sh'
       - '.github/workflows/docker-test.yml'
   push:
     branches:
@@ -20,6 +21,7 @@ on:
       - 'frontend/Dockerfile'
       - 'frontend/nginx.conf'
       - 'docker-compose.yml'
+      - 'scripts/test-docker-integration.sh'
 
 jobs:
   docker-integration-test:

--- a/scripts/test-docker-integration.sh
+++ b/scripts/test-docker-integration.sh
@@ -199,23 +199,37 @@ echo -e "${GREEN}✅ Portfolios verified (found $PORTFOLIO_COUNT portfolios)${NC
 if [ "${RUN_E2E_TESTS}" = "true" ]; then
     echo -e "${BLUE}🎭 Running Playwright E2E tests against Docker stack...${NC}"
 
-    # Check if Playwright is available
-    if ! command -v pnpm &> /dev/null; then
-        echo -e "${YELLOW}⚠️  pnpm not available - skipping E2E tests${NC}"
-    else
-        # Install Playwright browsers if needed (will skip if already installed)
-        echo -e "${BLUE}📦 Ensuring Playwright browsers are installed...${NC}"
-        cd frontend && pnpm exec playwright install chromium --with-deps > /dev/null 2>&1
+    # Run Playwright inside its official image instead of installing browsers on
+    # the host. `playwright install [--with-deps]` reproducibly hung CI runners
+    # for ~20 min while provisioning the browser; the official image ships
+    # Chromium + all OS deps prebaked (PLAYWRIGHT_BROWSERS_PATH=/ms-playwright).
+    #
+    # The container joins the running compose network and targets the frontend
+    # service directly (works identically on Linux CI and local macOS, unlike
+    # --network host). The project's own node_modules is mounted so the test
+    # files, config, and @playwright/test version match the image tag below.
+    PW_VERSION=$(node -p "require('./frontend/node_modules/@playwright/test/package.json').version" 2>/dev/null || echo "1.59.1")
+    PW_IMAGE="mcr.microsoft.com/playwright:v${PW_VERSION}-noble"
 
-        # Run E2E tests against Docker stack
-        if PLAYWRIGHT_BASE_URL="${TEST_URL}" pnpm run test:e2e; then
-            echo -e "${GREEN}✅ E2E tests passed${NC}"
-        else
-            echo -e "${RED}❌ E2E tests failed${NC}"
-            cd ..
-            exit 1
-        fi
-        cd ..
+    FRONTEND_CID=$(docker compose ps -q frontend)
+    if [ -z "$FRONTEND_CID" ]; then
+        echo -e "${RED}❌ Could not find running frontend container for E2E${NC}"
+        exit 1
+    fi
+    PW_NETWORK=$(docker inspect "$FRONTEND_CID" \
+        --format '{{range $k, $v := .NetworkSettings.Networks}}{{println $k}}{{end}}' | head -1)
+
+    echo -e "${BLUE}   image=${PW_IMAGE} network=${PW_NETWORK} baseURL=http://frontend:80${NC}"
+    if docker run --rm --network "${PW_NETWORK}" \
+        -v "$(pwd)/frontend:/work" -w /work \
+        -e CI=true \
+        -e PLAYWRIGHT_BASE_URL="http://frontend:80" \
+        "${PW_IMAGE}" \
+        npx --no-install playwright test; then
+        echo -e "${GREEN}✅ E2E tests passed${NC}"
+    else
+        echo -e "${RED}❌ E2E tests failed${NC}"
+        exit 1
     fi
 else
     echo -e "${YELLOW}ℹ️  Skipping E2E tests (set RUN_E2E_TESTS=true to run them)${NC}"


### PR DESCRIPTION
## Problem

The `docker-integration-test` job's E2E phase has hung CI runners for ~20 minutes (until the job timeout) since early June. Tracing it:

- apt system deps install fine (`needrestart` handled),
- the first browser artifact downloads in **~1 second** (CDN is fast),
- then `playwright install` **freezes for ~12 min after the download hits 100%** — during extraction / the next-artifact fetch — with zero output.

It's an environmental hang in host-side browser provisioning on the runner, reproducible and unrelated to any app code. Caching/retries don't help because the download isn't what fails.

## Fix

Stop installing browsers on the host. Run the E2E tests inside the **official Playwright image** (`mcr.microsoft.com/playwright:v<version>-noble`), which ships Chromium + all OS deps prebaked (`PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`).

Details:
- **Network:** the container joins the running compose network and targets the `frontend` service at `http://frontend:80`. The network name is detected dynamically via `docker inspect` because the stack uses a custom `app-network` (not the default `_default`). This is portable across Linux CI and local macOS — unlike `--network host`.
- **Version pinning:** the image tag is derived from the installed `@playwright/test` version, so it can't silently drift out of sync with the test runner.
- **No workflow change needed:** the existing Node/pnpm/`pnpm install` steps still populate the `node_modules` that the container mounts.

## Validation

Ran the full integration script locally with `RUN_E2E_TESTS=true`:

```
🎭 image=mcr.microsoft.com/playwright:v1.59.1-noble network=investment-portfolio-manager_app-network baseURL=http://frontend:80
Running 38 tests using 1 worker
...
15 skipped
23 passed (56.3s)
✅ E2E tests passed
✅ All Docker integration tests passed!
```

No hang; full bash integration suite + browser E2E green. (The 15 skips are pre-existing conditional tests that skip without optional data.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)